### PR TITLE
ldap searches: do not subinitial search "uid"

### DIFF
--- a/src/main/java/org/esupportail/esupsignature/ldap/PersonLdapRepository.java
+++ b/src/main/java/org/esupportail/esupsignature/ldap/PersonLdapRepository.java
@@ -13,5 +13,5 @@ public interface PersonLdapRepository extends LdapRepository<PersonLdap> {
     List<PersonLdap> findByMail(String mail);
     List<PersonLdap> findByUid(String uid);
     List<PersonLdap> findByCnIgnoreCaseOrDisplayNameIgnoreCaseOrUidOrMail(String cn, String displayName, String uid, String mail);
-    List<PersonLdap> findByDisplayNameStartingWithIgnoreCaseOrCnStartingWithIgnoreCaseOrDisplayNameStartingWithIgnoreCaseOrUidStartingWithOrMailStartingWith(String cn, String displayName, String uid, String mail);
+    List<PersonLdap> findByDisplayNameStartingWithIgnoreCaseOrCnStartingWithIgnoreCaseOrDisplayNameStartingWithIgnoreCaseOrUidOrMailStartingWith(String cn, String displayName, String uid, String mail);
 }

--- a/src/main/java/org/esupportail/esupsignature/service/ldap/LdapPersonService.java
+++ b/src/main/java/org/esupportail/esupsignature/service/ldap/LdapPersonService.java
@@ -46,7 +46,7 @@ public class LdapPersonService {
             ldapTemplateSelected = ldapTemplates.get(ldapTemplateName);
         }
         if (ldapTemplateSelected != null) {
-            List<PersonLdap> results = personLdapRepository.findByDisplayNameStartingWithIgnoreCaseOrCnStartingWithIgnoreCaseOrDisplayNameStartingWithIgnoreCaseOrUidStartingWithOrMailStartingWith(searchString, searchString, searchString, searchString);
+            List<PersonLdap> results = personLdapRepository.findByDisplayNameStartingWithIgnoreCaseOrCnStartingWithIgnoreCaseOrDisplayNameStartingWithIgnoreCaseOrUidOrMailStartingWith(searchString, searchString, searchString, searchString);
             List<PersonLdap> filteredPersons = new ArrayList<>();
             for(PersonLdap personLdap : results) {
                 if(personLdap.getEduPersonAffiliation().contains("member") || personLdap.getEduPersonAffiliation().contains("staff")) {


### PR DESCRIPTION
needed for openldap servers that "prevent clients from doing very inefficient non-indexed searches" using "size.unchecked"

Cf https://openldap.org/doc/admin24/limits.html

The commit replaces `UidStartingWith` with `Uid` in the method name