### PR TITLE
fix: say "yes" to upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:latest
-RUN apt update && apt upgrade && apt -y install openjdk-17-jdk-headless && apt install -y ghostscript
+RUN apt update && apt upgrade -y && apt install -y openjdk-17-jdk-headless && apt install -y ghostscript
 COPY target/esup-signature.war esup-signature.war
 COPY src/main/resources/application-docker.yml /tmp/application-docker.yml
 ENTRYPOINT ["java","-jar","/esup-signature.war","--spring.config.location=file:/tmp/application-docker.yml"]


### PR DESCRIPTION
J'ai cette erreur en exécutant `sudo docker-compose up` :

```
[...]
Step 2/5 : RUN apt update && apt upgrade && apt -y install openjdk-17-jdk-headless && apt install -y ghostscript
 ---> Running in b1bf263dc2a6
[...]
The following packages will be upgraded:
  libc-bin libc6
2 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 3361 kB of archives.
After this operation, 0 B of additional disk space will be used.
Do you want to continue? [Y/n] Abort.
The command '/bin/sh -c apt update && apt upgrade && apt -y install openjdk-17-jdk-headless && apt install -y ghostscript' returned a non-zero code: 1
ERROR: Service 'esup-signature' failed to build : Build failed
```

La commande échoue car `apt upgrade` demande la confirmation de mettre à jour les paquets `libc-bin` et `libc6`. Il faut ajouter `-y` pour confirmer automatiquement les mises à jour.