### PR TITLE
fix typo "extention"

### DIFF
--- a/src/main/resources/templates/admin/workflows/update.html
+++ b/src/main/resources/templates/admin/workflows/update.html
@@ -70,7 +70,7 @@
                                         <li>[originalFileName] : nom original du document</li>
                                         <li>[signedFileName] : nom original du document</li>
                                         <li>[fileNameOnly] : nom document sans extension</li>
-                                        <li>[fileExtension] : extention du document</li>
+                                        <li>[fileExtension] : extension du document</li>
                                         <li>[title] : titre du parapheur</li>
                                         <li>[id] : identifiant du parapheur</li>
                                         <li>[worflowName] : nom du circuit</li>


### PR DESCRIPTION
Corriger une faute de frappe dans la description du Modèle de nommage : _[fileExtension] : exten**t**ion du document_.