### PR TITLE
fix: NPE lors de la signature de documents non-PDF

### DIFF
--- a/src/main/java/org/esupportail/esupsignature/entity/Document.java
+++ b/src/main/java/org/esupportail/esupsignature/entity/Document.java
@@ -167,6 +167,6 @@ public class Document {
     }
 
     public boolean isPdf() {
-        return contentType.equals("application/pdf");
+        return "application/pdf".equals(contentType);
     }
 }

--- a/src/main/java/org/esupportail/esupsignature/service/DocumentService.java
+++ b/src/main/java/org/esupportail/esupsignature/service/DocumentService.java
@@ -74,7 +74,7 @@ public class DocumentService {
 		document.setCreateDate(new Date());
 		document.setFileName(name);
 		document.setContentType(contentType);
-		if(contentType.equals("application/pdf")) {
+		if("application/pdf".equals(contentType)) {
 			document.setNbPages(getNbPages(new ByteArrayInputStream(bytes)));
 		}
 		BigFile bigFile = new BigFile();


### PR DESCRIPTION
Pour un document non-PDF, DSS produit un conteneur ASiC-E dont l'extension n'est pas reconnue par Files.probeContentType() qui retourne null, ce qui fait planter contentType.equals("application/pdf") dans DocumentService.createDocument().

Même correction appliquée à Document.isPdf().